### PR TITLE
debian: use gzip compression for deb on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ script:
     cat debian/changelog | awk "NR == 1 {\$2 = substr(\$2, 1, length(\$2) - 1) \"+${SUITE})\"}{print}" > debian/changelog.new;
     mv debian/changelog.new debian/changelog;
   fi
-- ${DOCKER_EXEC} dpkg-buildpackage -i -us -uc -b
+- ${DOCKER_EXEC} env WORKAROUND_BINTRAY_DEB_SUPPORT=1
+    dpkg-buildpackage -i -us -uc -b
 
 before_deploy:
 - |

--- a/debian/rules
+++ b/debian/rules
@@ -5,3 +5,9 @@ export DPKG_GENSYMBOLS_CHECK_LEVEL=4
 
 %:
 	dh $@ --fail-missing
+
+ifneq ($(WORKAROUND_BINTRAY_DEB_SUPPORT),)
+override_dh_builddeb:
+	dh_builddeb -- -Zgzip
+
+endif


### PR DESCRIPTION
Bintray only accepts packages with control.data.gz. While newer dpkg-deb generates packages with controldata.xz instead, Bintray refuses to accept them with malformed package error.